### PR TITLE
feat: support multiple platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
             quay.io/aminvakil/alpine-ftp-server-tls:${{ env.TAG }}
             quay.io/aminvakil/alpine-ftp-server-tls:${{ env.VERSION }}
             quay.io/aminvakil/alpine-ftp-server-tls:latest
+          platforms: |
+            linux/386
+            linux/amd64
+            linux/arm64
+            linux/ppc64le
         env:
           TAG: ${{ steps.get_version.outputs.TAG }}
           VERSION: ${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Add support for building image for multiple platforms.

closes #43

### Manifests at quay

Following screenshot shows new manifests available.

_52.. tag is a push with the PR changes (386, amd64, arm64, ppc64le)
46.. tag is main push without the PR changes (only amd64)_

<img width="250" alt="image" src="https://github.com/user-attachments/assets/8535d4b7-0fb0-4702-9e6a-97ef5d21ed57">

